### PR TITLE
Add OpenAI markdown heading conversion to Slack mrkdwn

### DIFF
--- a/listeners/llm_caller.py
+++ b/listeners/llm_caller.py
@@ -35,7 +35,7 @@ def markdown_to_slack(content: str) -> str:
     # Split the input string into parts based on code blocks and inline code
     parts = re.split(r"(?s)(```.+?```|`[^`\n]+?`)", content)
 
-    # Apply the bold, italic, and strikethrough formatting to text not within code
+    # Apply the bold, italic, strikethrough, and heading formatting to text not within code
     result = ""
     for part in parts:
         if part.startswith("```") or part.startswith("`"):
@@ -53,6 +53,7 @@ def markdown_to_slack(content: str) -> str:
                 (r"\*\*(?!\s)([^\*\n]+?)(?<!\s)\*\*", r"*\1*"),  # **bold** to *bold*
                 (r"__(?!\s)([^_\n]+?)(?<!\s)__", r"*\1*"),  # __bold__ to *bold*
                 (r"~~(?!\s)([^~\n]+?)(?<!\s)~~", r"~\1~"),  # ~~strike~~ to ~strike~
+                (r"^#{1,6} (.+)$", r"*\1*"),  # #heading to *heading*
             ]:
                 part = re.sub(o, n, part)
             result += part


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

This PR adds support for converting OpenAI markdown headings to Slack mrkdwn in llm_caller.py. The goal is to ensure that markdown headings (formatted with #) are properly converted into Slack’s bold formatting so that they display correctly.

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
