### PR TITLE
feat: rename app display name from assistant to agent

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "display_information": {
-    "name": "Bolt Python Assistant"
+    "name": "Bolt Python Agent"
   },
   "features": {
     "app_home": {
@@ -9,11 +9,11 @@
       "messages_tab_read_only_enabled": false
     },
     "bot_user": {
-      "display_name": "Bolt Python Assistant",
+      "display_name": "Bolt Python Agent",
       "always_online": false
     },
     "assistant_view": {
-      "assistant_description": "Hi, I am an assistant built using Bolt for Python. I am here to help you out!",
+      "assistant_description": "Hi, I am an agent built using Bolt for Python. I am here to help you out!",
       "suggested_prompts": []
     }
   },


### PR DESCRIPTION
### Type of change <!-- place an x in the [ ] that applies -->

- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

shortens the display name of the app from assistant to agent to prevent app manifest error during intialization

### Requirements <!-- place an x in each [ ] that applies -->

- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
