### PR TITLE
fix: add support for streaming messages in enterprise orgs

### DIFF
--- a/listeners/assistant/assistant.py
+++ b/listeners/assistant/assistant.py
@@ -67,9 +67,9 @@ def respond_in_assistant_thread(
 ):
     try:
         channel_id = payload["channel"]
-        team_id = payload["team"]
+        team_id = context.team_id
         thread_ts = payload["thread_ts"]
-        user_id = payload["user"]
+        user_id = context.user_id
         user_message = payload["text"]
 
         set_status(


### PR DESCRIPTION
### Type of change <!-- place an x in the [ ] that applies -->

- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This pull request adds support for streaming messages in Enterprise Orgs. The current implementation fails to get the `team_id` when DMs are sent to the bot in an Enterprise Org.

### Reviewers

You can test with the following steps:

1. Enterprise Org
    1. Create & install the app on an Enterprise Org (e.g. Developer Sandbox)
    2. Send a DM to the bot & confirm it responds
    3. Invite the bot to a public channel
    4. `@Mention` the bot and confirm it responds
    5. `@Mention` the bot in a thread and confirm it responds
6. Standalone Workspace
    1. Create & install the app on an Standalone Workspace
    2. Send a DM to the bot & confirm it responds
    3. Invite the bot to a public channel
    4. `@Mention` the bot and confirm it responds
    5. `@Mention` the bot in a thread and confirm it responds

### Requirements <!-- place an x in each [ ] that applies -->

- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
