### PR TITLE
docs: instruct virtual environment setup with the slack cli before configuring providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ slack create my-bolt-python-assistant --template slack-samples/bolt-python-assis
 cd my-bolt-python-assistant
 ```
 
+#### Setup your python virtual environment
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate  # for Windows OS, .\.venv\Scripts\Activate instead should work
+```
+
+#### Install dependencies
+
+```sh
+pip install -r requirements.txt
+```
+
 #### Creating the Slack app
 
 Use the following command to add your new Slack app to your development workspace. Choose a "local" app environment for upcoming development:
@@ -44,7 +57,7 @@ Use the following command to add your new Slack app to your development workspac
 slack install
 ```
 
-After the Slack app has been created you're all set to configure the LLM provider!
+After the Slack app has been created you're all set to [configure the LLM provider](#providers)!
 
 ### Using Terminal
 


### PR DESCRIPTION
### Type of change <!-- place an x in the [ ] that applies -->

- [x] Documentation

### Summary

This PR updates the `README` to include virtual environment setup steps with the Slack CLI as well as linking ahead to the section for "providers" once this is complete.

### Requirements <!-- place an x in each [ ] that applies -->

- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
