### PR TITLE
chore: normalize Slack CLI config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 slack-sdk==3.43.0
 slack-bolt==1.30.0
-slack-cli-hooks<1.0.0
+slack-cli-hooks==0.3.0
 
 # If you use a different LLM vendor, replace this dependency
 openai==2.45.0
@@ -8,4 +8,3 @@ openai==2.45.0
 pytest==9.1.1
 ruff==0.15.21
 python-dotenv==1.2.2
-slack-cli-hooks<1.0.0


### PR DESCRIPTION
Normalizes this sample's Slack CLI config to match the rest of the Bolt samples, part of a fleet-wide standardization pass:

- stop gitignoring `.slack/config.json` so the committed CLI project config is consistent (JS/TS + py-search)
- pin `slack-cli-hooks==0.3.0` for reproducible installs (Python only)

Opened as a **draft** for review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)